### PR TITLE
chore(bower): remove moot `version` property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "hud-ui",
-  "version": "0.7.11",
   "authors": [],
   "private": true,
   "ignore": [


### PR DESCRIPTION
Per the [Bower spec](https://github.com/bower/bower.json-spec#version) the version property is not used for anything.  

One of the maintainers also says that they are [not likely to use it in the future](http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property).

I did not see a Gulp task relevant to the bower file, but if I missed it let me know and I can add it to the PR.