### PR TITLE
feat(folders): Support moving bookmarks into folders OZBE7

### DIFF
--- a/app/js/api/Library.js
+++ b/app/js/api/Library.js
@@ -20,7 +20,7 @@ module.exports.LibraryApi = {
             type: 'PUT',
             dataType: 'json',
             contentType: 'application/json',
-            url: url,
+            url: url + 'update_all/',
             data: JSON.stringify(libraryEntries)
         }).fail(function(response) {
             console.error('Error updating library', response.status,

--- a/app/js/components/library/FolderTile.jsx
+++ b/app/js/components/library/FolderTile.jsx
@@ -60,7 +60,7 @@ var FolderTile = React.createClass({
                 'drag-hover': this.state.dropHighlight
             }),
             entryIcons = folder.entries.map(function(entry) {
-                var src = entry.listing.imageMediumUrl;
+                var src = entry.listing.large_icon.url;
 
                 return <img key={entry.listing.id} src={src} draggable="false" />;
             }),

--- a/app/js/store/FolderLibrary.js
+++ b/app/js/store/FolderLibrary.js
@@ -18,7 +18,9 @@ function updateFolderName(newFolder, entry) {
         (newFolder instanceof Folder ? newFolder.name : newFolder) :
         null;
 
-    return Object.freeze({folder: folderName, listing: entry.listing});
+    return Object.freeze({folder: folderName,
+                          listing: entry.listing,
+                          id: entry.id});
 }
 
 /**

--- a/app/js/store/Library.js
+++ b/app/js/store/Library.js
@@ -23,7 +23,6 @@ var LibraryStore = Reflux.createStore({
             return Object.freeze(e);
         }));
 
-
         this.trigger(this.library);
     },
 
@@ -34,7 +33,10 @@ var LibraryStore = Reflux.createStore({
     },
 
     onUpdateLibrary: function(libraryEntries) {
-        LibraryApi.save(libraryEntries).then(this.updateLibrary.bind(this));
+        LibraryApi.save(libraryEntries).then(
+            // GET to ensure updateLibrary happens after GET from onFetchLibrary()
+            ()=>LibraryApi.get()).then(
+                ()=>this.updateLibrary(libraryEntries));
     },
 
     onRemoveFromLibrary: function(libraryEntry) {


### PR DESCRIPTION
OZBE7 = ozone-development/ozp-backend#7

There are a couple of thing with the change in LibraryStore worth
noting. Prior to this new backend change the api call /library was used
for both gets and puts. When used to update that endpoint returned data,
data that was used in the updateLibrary function. With the new backend's
/update_all endpoint, that data is no longer returned, so I just forward
libraryEntries onto updateLibrary.

The second thing to note has to do with timing (race condition?), and
why I had to add a LibraryApi.get() to onUpdateLibrary(). HUD, to keep
it synced with Center, calls fetchLibrary (makes an API call) whenever
there is a focus event. When updating the folder name in the folder
modal, both onFetchLibrary() and onUpdateLibrary() are called on
focusing. With the new backend, but not the old one, the updateLibrary()
call returns before the onFetchLibrary() returns. Put another way, the
PUT completes before the GET completes. React properly renders the data
after the PUT and shortly thereafter re-renders now-stale data from the
GET. You can avoid this using a short setTimeout period to delay calling
updateLibrary, but determining how long the delay could be difficult and
or network dependent. Instead, I've inserted a call to LibraryApi.get()
which should take about the same amount of time as the call in
onFetchLibrary (the Center-syncing one) but start later (after the PUT),
hopefully forestalling the race.