### PR TITLE
Adding application launch tracking for new tab and webtop launches

### DIFF
--- a/app/js/Constants.js
+++ b/app/js/Constants.js
@@ -10,5 +10,9 @@ module.exports = {
         ORG_STEWARD: 1,
         APPSMALL_STEWARD: 2,
         ADMIN: 3
+    },
+    metrics: {
+    	applicationsNewTab: 'Applications - New Tab',
+    	applicationsWebtop: 'Applications - Webtop'
     }
 };

--- a/app/js/components/library/LibraryTile.jsx
+++ b/app/js/components/library/LibraryTile.jsx
@@ -18,6 +18,14 @@ var ActionMenu = React.createClass({
             listing = entry.listing,
             removeBookmark = LibraryActions.removeFromLibrary.bind(null, entry);
 
+        var reportLaunchWebtop = function() {
+            window._paq.push(['trackEvent', Constants.metrics.applicationsWebtop, listing.title, listing.agencyShort]);
+        };
+
+        var reportLaunchNewTab = function() {
+            window._paq.push(['trackEvent', Constants.metrics.applicationsNewTab, listing.title, listing.agencyShort]);
+        };
+
         //use hidden checkbox to manage menu toggle state
         return (
             <label className="LibraryTile__actionMenu">
@@ -27,12 +35,12 @@ var ActionMenu = React.createClass({
                 </span>
                 <ul>
                     <li>
-                        <WebtopLaunchLink listing={listing} newTab={false}>
+                        <WebtopLaunchLink listing={listing} newTab={false} onClick={reportLaunchWebtop}>
                             Launch in Webtop
                         </WebtopLaunchLink>
                     </li>
                     <li>
-                        <TabLaunchLink listing={listing} newTab={true}>
+                        <TabLaunchLink listing={listing} newTab={true} onClick={reportLaunchNewTab}>
                             Launch in new tab
                         </TabLaunchLink>
                     </li>
@@ -101,6 +109,14 @@ var LibraryTile = React.createClass({
                 tab: true
             };
 
+        var checkIfLaunchedInWebtop = function(isLaunchedInWebtop) {
+            var eventName = Constants.metrics.applicationsNewTab;
+            if(isLaunchedInWebtop) {
+                eventName = Constants.metrics.applicationsWebtop;
+            }
+
+            window._paq.push(['trackEvent', eventName, listing.title, listing.agencyShort]);
+        };
 
         return (
             <div className={classes} data-listing-id={listing.id}
@@ -108,7 +124,7 @@ var LibraryTile = React.createClass({
                     onDragLeave={this.onDragLeave} onDrop={this.onDrop}
                     draggable="true" onDragStart={this.onDragStart}>
                 <ActionMenu entry={entry} />
-                <LaunchLink listing={listing} newTab={newTabSpec} draggable="false">
+                <LaunchLink listing={listing} newTab={newTabSpec} draggable="false" afterClick={checkIfLaunchedInWebtop}>
                     <img ref="banner" draggable="false" className="LibraryTile__img"
                         src={listing.imageLargeUrl} />
                 </LaunchLink>


### PR DESCRIPTION
Will allow for the HUD to report application launches to metrics server in 2 categories, launches to webtop, and launches to a new tab.

This depends upon the launch-type-link branch from ozp-react-commons ozone-development/ozp-react-commons#29