### PR TITLE
fix(folderTile): folders will not not prompt a name change upon creat…

### DIFF
--- a/app/js/components/folder/FolderTitle.jsx
+++ b/app/js/components/folder/FolderTitle.jsx
@@ -12,7 +12,7 @@ var FolderTitle = React.createClass({
     getInitialState: function() {
         var newFolderName = NewFolderStore.getDefaultData();
 
-        return { editing: this.props.name === newFolderName, error: false };
+        return { editing: false, error: false };
     },
 
     componentDidMount: function() {

--- a/app/js/components/folder/FolderTitle.jsx
+++ b/app/js/components/folder/FolderTitle.jsx
@@ -10,8 +10,6 @@ var FolderTitle = React.createClass({
     mixins: [Reflux.ListenerMixin],
 
     getInitialState: function() {
-        var newFolderName = NewFolderStore.getDefaultData();
-
         return { editing: false, error: false };
     },
 


### PR DESCRIPTION
…ion instead they will be renameable after the creation. This will fix #168 in hud where when clicking into a folder was not saving the name